### PR TITLE
Custom release of xlcore

### DIFF
--- a/src/commands/install_steam_tool.rs
+++ b/src/commands/install_steam_tool.rs
@@ -102,7 +102,7 @@ impl InstallSteamToolCommand {
                 r#"#!/bin/env bash
 
 # Prevents launching twice.
-if [ $1 == "run" ]; then sleep 1; exit; fi
+if [[ "$1" == "run" ]]; then sleep 1; exit; fi
 
 tooldir="$(realpath "$(dirname "$0")")"
 

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 use eframe::egui::{self, Layout};
 use flate2::read::GzDecoder;
 use log::{debug, error, info};
-use octocrab::models::repos::Release;
 use reqwest::Url;
 use std::{
     env,
@@ -43,6 +42,9 @@ pub struct LaunchCommand {
     xlcore_release_asset: String,
 
     /// The URL to a custom release of XIVLauncher.Core. This will override the `xlcore-repo-owner` and `xlcore-repo-name` arguments.
+    /// This should be a URL prefix that contains:
+    /// - A file called `version` that contains the version of the release.
+    /// - A file called <xlcore-release-asset> that contains the tar.gz archive of the release.
     #[clap(default_value = "", long = "custom-xlcore-release")]
     custom_xlcore_release: Url,
 

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -75,43 +75,42 @@ impl LaunchCommand {
 
         {
             // Query the GitHub API or custom release Url for release information.
-            let (remote_version, remote_release) = if let Some(custom_xlcore_url) = self.custom_xlcore_release_url {
-                let version_url = custom_xlcore_url.join("version").unwrap();
-                let release_url = custom_xlcore_url
-                    .join(&self.xlcore_release_asset)
-                    .unwrap();
-                info!("version url: {}", version_url);
-                info!("release url:{}", release_url);
-                let response = reqwest::get(version_url).await?;
-                (response.text().await?, release_url)
-            } else {
-                let octocrab = octocrab::instance();
-                let repo = octocrab.repos(&self.xlcore_repo_owner, &self.xlcore_repo_name);
-                let release = match repo.releases().get_latest().await {
-                    Ok(release) => release,
-                    Err(err) => {
+            let (remote_version, remote_release) =
+                if let Some(custom_xlcore_url) = self.custom_xlcore_release_url {
+                    let version_url = custom_xlcore_url.join("version").unwrap();
+                    let release_url = custom_xlcore_url.join(&self.xlcore_release_asset).unwrap();
+                    info!("Custom xlcore version url: {}", version_url);
+                    info!("Custom xlcore release url:{}", release_url);
+                    let response = reqwest::get(version_url).await?;
+                    (response.text().await?, release_url)
+                } else {
+                    let octocrab = octocrab::instance();
+                    let repo = octocrab.repos(&self.xlcore_repo_owner, &self.xlcore_repo_name);
+                    let release = match repo.releases().get_latest().await {
+                        Ok(release) => release,
+                        Err(err) => {
+                            bail!(
+                                "Failed to obtain release information for {}/{}: {:?}",
+                                self.xlcore_repo_owner,
+                                self.xlcore_repo_name,
+                                err.source()
+                            );
+                        }
+                    };
+                    let release_url = release
+                        .assets
+                        .iter()
+                        .find(|asset| asset.name == self.xlcore_release_asset);
+                    if let Some(asset) = release_url {
+                        (release.tag_name, asset.browser_download_url.clone())
+                    } else {
                         bail!(
-                            "Failed to obtain release information for {}/{}: {:?}",
-                            self.xlcore_repo_owner,
-                            self.xlcore_repo_name,
-                            err.source()
+                            "Failed to find asset {} in release {}",
+                            self.xlcore_release_asset,
+                            release.tag_name
                         );
                     }
                 };
-                let release_url = release
-                    .assets
-                    .iter()
-                    .find(|asset| asset.name == self.xlcore_release_asset);
-                if let Some(asset) = release_url {
-                    (release.tag_name, asset.browser_download_url.clone())
-                } else {
-                    bail!(
-                        "Failed to find asset {} in release {}",
-                        self.xlcore_release_asset,
-                        release.tag_name
-                    );
-                }
-            };
 
             // Install XIVLauncher or do an update check if version data already exists.
             match fs::read_to_string(self.install_directory.join(XLCORE_VERSIONDATA_FILENAME)) {

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -193,7 +193,7 @@ impl LaunchCommand {
 
     async fn get_release_web(
         base_url: Url,
-        xlcore_release_asset: &String,
+        xlcore_release_asset: &str,
     ) -> Result<(String, Url)> {
         let version_url = base_url.join("version")?;
         let release_url = base_url.join(xlcore_release_asset)?;

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{bail, Result};
 use bytes::Buf;
 use clap::Parser;
 use eframe::egui::{self, Layout};
@@ -41,12 +41,18 @@ pub struct LaunchCommand {
     )]
     xlcore_release_asset: String,
 
-    /// The URL to a custom release of XIVLauncher.Core. This will override the `xlcore-repo-owner` and `xlcore-repo-name` arguments.
+    /// The URL to a release of XIVLauncher.Core. This conflicts with `xlcore-repo-owner` and `xlcore-repo-name`
+    /// as it overrides the default git-based release system.
+    ///
     /// This should be a URL prefix that contains:
     /// - A file called `version` that contains the version of the release.
-    /// - A file called <xlcore-release-asset> that contains the tar.gz archive of the release.
-    #[clap(long = "custom-xlcore-release-url")]
-    custom_xlcore_release_url: Option<Url>,
+    /// - A file with the name of `<xlcore-release-asset>` that contains the tar.gz archive of the release.
+    #[clap(
+        long = "xlcore-web-release-url-base",
+        conflicts_with = "xlcore_repo_name",
+        conflicts_with = "xlcore_repo_owner"
+    )]
+    xlcore_web_release_url_base: Option<Url>,
 
     /// The location of a tarball that contains a static build of aria2c.
     #[clap(
@@ -73,88 +79,61 @@ impl LaunchCommand {
     pub async fn run(self) -> anyhow::Result<()> {
         debug!("Attempting launch with args: {self:?}");
 
-        {
-            // Query the GitHub API or custom release Url for release information.
-            let (remote_version, remote_release) =
-                if let Some(custom_xlcore_url) = self.custom_xlcore_release_url {
-                    let version_url = custom_xlcore_url.join("version").unwrap();
-                    let release_url = custom_xlcore_url.join(&self.xlcore_release_asset).unwrap();
-                    info!("Custom xlcore version url: {}", version_url);
-                    info!("Custom xlcore release url:{}", release_url);
-                    let response = reqwest::get(version_url).await?;
-                    (response.text().await?, release_url)
-                } else {
-                    let octocrab = octocrab::instance();
-                    let repo = octocrab.repos(&self.xlcore_repo_owner, &self.xlcore_repo_name);
-                    let release = match repo.releases().get_latest().await {
-                        Ok(release) => release,
-                        Err(err) => {
-                            bail!(
-                                "Failed to obtain release information for {}/{}: {:?}",
-                                self.xlcore_repo_owner,
-                                self.xlcore_repo_name,
-                                err.source()
-                            );
-                        }
-                    };
-                    let release_url = release
-                        .assets
-                        .iter()
-                        .find(|asset| asset.name == self.xlcore_release_asset);
-                    if let Some(asset) = release_url {
-                        (release.tag_name, asset.browser_download_url.clone())
-                    } else {
-                        bail!(
-                            "Failed to find asset {} in release {}",
-                            self.xlcore_release_asset,
-                            release.tag_name
-                        );
-                    }
-                };
+        // Query the GitHub API or web release Url for release information.
+        let (remote_version, remote_release_url) = match self.xlcore_web_release_url_base {
+            Some(url) => Self::get_release_web(url, &self.xlcore_release_asset).await?,
+            None => {
+                Self::get_release_github(
+                    &self.xlcore_repo_owner,
+                    &self.xlcore_repo_name,
+                    &self.xlcore_release_asset,
+                )
+                .await?
+            }
+        };
 
-            // Install XIVLauncher or do an update check if version data already exists.
-            match fs::read_to_string(self.install_directory.join(XLCORE_VERSIONDATA_FILENAME)) {
-                Ok(ver) => {
-                    if !self.skip_update {
-                        if ver == remote_version {
-                            info!("XIVLauncher is up to date!");
-                        } else {
-                            Self::open_xlm_wait_ui();
-                            info!("XIVLauncher is out of date - starting update");
-                            Self::install_or_update_xlcore(
-                                &remote_version,
-                                remote_release,
-                                self.aria_download_url,
-                                &self.install_directory,
-                            )
-                            .await?;
-                            info!("Successfully updated XIVLauncher to the latest version.")
-                        }
+        // Install XIVLauncher or do an update check if version data already exists locally.
+        match fs::read_to_string(self.install_directory.join(XLCORE_VERSIONDATA_FILENAME)) {
+            Ok(ver) => {
+                if !self.skip_update {
+                    if ver == remote_version {
+                        info!("XIVLauncher is up to date!");
                     } else {
-                        info!("Skip update enabled, not attempting to update XIVLauncher.")
-                    }
-                }
-                Err(err) => {
-                    if err.kind() == ErrorKind::NotFound {
                         Self::open_xlm_wait_ui();
-                        info!("Unable to obtain local version data for XIVLauncher - installing from latest tag");
+                        info!("XIVLauncher is out of date - starting update");
                         Self::install_or_update_xlcore(
                             &remote_version,
-                            remote_release,
+                            remote_release_url,
                             self.aria_download_url,
                             &self.install_directory,
                         )
                         .await?;
-                        info!("Successfully installed XIVLauncher")
-                    } else {
-                        error!(
-                            "Something went wrong whilst checking for XIVLauncher: {:?}",
-                            err
-                        );
+                        info!("Successfully updated XIVLauncher to the latest version.")
                     }
+                } else {
+                    info!("Skip update enabled, not attempting to update XIVLauncher.")
                 }
-            };
-        }
+            }
+            Err(err) => {
+                if err.kind() == ErrorKind::NotFound {
+                    Self::open_xlm_wait_ui();
+                    info!("Unable to obtain local version data for XIVLauncher - installing latest release");
+                    Self::install_or_update_xlcore(
+                        &remote_version,
+                        remote_release_url,
+                        self.aria_download_url,
+                        &self.install_directory,
+                    )
+                    .await?;
+                    info!("Successfully installed XIVLauncher")
+                } else {
+                    error!(
+                        "Something went wrong whilst checking for XIVLauncher: {:?}",
+                        err
+                    );
+                }
+            }
+        };
 
         Self::close_xlm_wait_ui();
 
@@ -175,6 +154,58 @@ impl LaunchCommand {
         info!("XIVLauncher process exited with exit code {:?}", cmd.code());
 
         Ok(())
+    }
+
+    async fn get_release_github(
+        xlcore_repo_owner: &String,
+        xlcore_repo_name: &String,
+        xlcore_release_asset: &String,
+    ) -> Result<(String, Url)> {
+        let octocrab = octocrab::instance();
+        let repo = octocrab.repos(xlcore_repo_owner, xlcore_repo_name);
+        let release = match repo.releases().get_latest().await {
+            Ok(release) => release,
+            Err(err) => {
+                bail!(
+                    "Failed to obtain release information for {}/{}: {:?}",
+                    xlcore_repo_owner,
+                    xlcore_repo_name,
+                    err.source()
+                );
+            }
+        };
+
+        let release_url = release
+            .assets
+            .iter()
+            .find(|asset| &asset.name == xlcore_release_asset);
+
+        if let Some(asset) = release_url {
+            Ok((release.tag_name, asset.browser_download_url.clone()))
+        } else {
+            bail!(
+                "Failed to find asset {} in release {}",
+                xlcore_release_asset,
+                release.tag_name
+            );
+        }
+    }
+
+    async fn get_release_web(
+        base_url: Url,
+        xlcore_release_asset: &String,
+    ) -> Result<(String, Url)> {
+        let version_url = base_url.join("version")?;
+        let release_url = base_url.join(xlcore_release_asset)?;
+
+        info!("XLCore web release asset url:{}", release_url);
+        info!("XLCore web release version url: {}", version_url);
+
+        let response = reqwest::get(version_url).await?;
+        if !response.status().is_success() {
+            bail!("{}", format!("{:?}", response.error_for_status()))
+        }
+        Ok((response.text().await?, release_url))
     }
 
     /// Creates a new XLCore installation or overwrites an existing XLCore installion with a new one.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::{env::temp_dir, fs::File};
 
 #[derive(Debug, Clone, Parser)]
 enum Command {
-    Launch(LaunchCommand),
+    Launch(Box<LaunchCommand>),
     InstallSteamTool(InstallSteamToolCommand),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::{env::temp_dir, fs::File};
 
 #[derive(Debug, Clone, Parser)]
 enum Command {
-    Launch(Box<LaunchCommand>),
+    Launch(LaunchCommand),
     InstallSteamTool(InstallSteamToolCommand),
 }
 


### PR DESCRIPTION
Hi Blooym!

Thank you for this awsome project that handles the xlcore compatibility issue well enough for steamdeck/linux users!

I have tried it with our fork in ottercorp (CN fork of xl stuff) and it worked well, but the only issue is that accessing github in CN is hard (and xlm is doing so to check release version & updating xlcore) so I added a new argument that accepts a custom url for the xlcore version check & update. It's optional so if it's not provided it should act the same.

You can test the new argument by adding `--custom-xlcore-release-url="https://s3.otters.cloud/xlcore/distrib/"`

This is my first rust contribution so let me know if there's anything I need to change. :)