### PR TITLE
feat: run launch-ui in a separate application

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,9 @@ async fn main() -> Result<()> {
     match args.command {
         Command::Launch(cmd) => cmd.run().await,
         Command::InstallSteamTool(cmd) => cmd.run().await,
-        Command::InternalLaunchUI => Ok(ui::launch_ui_main()),
+        Command::InternalLaunchUI => {
+            ui::launch_ui_main();
+            Ok(())
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ use std::{env::temp_dir, fs::File};
 enum Command {
     Launch(Box<LaunchCommand>),
     InstallSteamTool(InstallSteamToolCommand),
+    #[clap(hide = true)]
+    LaunchUI,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -93,5 +95,6 @@ async fn main() -> Result<()> {
     match args.command {
         Command::Launch(cmd) => cmd.run().await,
         Command::InstallSteamTool(cmd) => cmd.run().await,
+        Command::LaunchUI => Ok(ui::launch_ui_main()),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ enum Command {
     Launch(Box<LaunchCommand>),
     InstallSteamTool(InstallSteamToolCommand),
     #[clap(hide = true)]
-    LaunchUI,
+    InternalLaunchUI,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -95,6 +95,6 @@ async fn main() -> Result<()> {
     match args.command {
         Command::Launch(cmd) => cmd.run().await,
         Command::InstallSteamTool(cmd) => cmd.run().await,
-        Command::LaunchUI => Ok(ui::launch_ui_main()),
+        Command::InternalLaunchUI => Ok(ui::launch_ui_main()),
     }
 }

--- a/src/ui/launchui.rs
+++ b/src/ui/launchui.rs
@@ -1,70 +1,99 @@
 use eframe::egui::{
     Align, CentralPanel, Direction, Layout, Spinner, TopBottomPanel, ViewportBuilder,
 };
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, RwLock,
+use std::{
+    io::{self, BufRead, Write},
+    sync::{mpsc, Arc, RwLock},
 };
-use winit::platform::wayland::EventLoopBuilderExtWayland;
 
-#[derive(Default)]
 pub struct LaunchUI {
-    /// Whether all egui windows should close next frame.
-    should_close: Arc<AtomicBool>,
-    /// The progress text to show while XLM is performing a setup.
-    pub progress_text: Arc<RwLock<&'static str>>,
+    child: std::process::Child,
+    // An Option is used to allow dropping the thread handle by consuming it.
+    stdin_thread: Option<std::thread::JoinHandle<()>>,
+    tx: mpsc::Sender<String>,
+}
+impl LaunchUI {
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::channel();
+
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("launch-ui")
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let mut stdin = child.stdin.take().unwrap();
+        let stdin_thread = std::thread::spawn(move || {
+            for msg in rx.iter() {
+                writeln!(stdin, "{msg}").unwrap();
+            }
+        });
+
+        Self {
+            child,
+            stdin_thread: Some(stdin_thread),
+            tx,
+        }
+    }
+    pub fn set_progress_text(&self, text: &str) {
+        self.tx.send(text.to_string()).unwrap();
+    }
+}
+impl Drop for LaunchUI {
+    fn drop(&mut self) {
+        self.stdin_thread.take().unwrap().join().unwrap();
+        self.child.kill().unwrap();
+    }
 }
 
-impl LaunchUI {
-    /// Starts a new Tokio task and displays an egui window displaying a "XIVLauncher is starting" message.
-    /// The egui window blocks inside of the task meaning it cannot be killed by aborting the thread.
-    /// To close the window you can call [`LaunchUI::kill`] which will close all existing windows.
-    pub fn spawn_background(&self) {
-        let close_copy = self.should_close.clone();
-        let progress_text_copy = self.progress_text.clone();
-        tokio::task::spawn(async move {
-            eframe::run_simple_native(
-                "XLM",
-                eframe::NativeOptions {
-                    event_loop_builder: Some(Box::new(|event_loop_builder| {
-                        event_loop_builder.with_any_thread(true);
-                    })),
-                    viewport: ViewportBuilder::default()
-                        .with_inner_size([800.0, 500.0])
-                        .with_resizable(false)
-                        .with_decorations(false),
-                    ..Default::default()
-                },
-                move |ctx, _frame| {
-                    if close_copy.load(Ordering::Relaxed) {
-                        std::process::exit(0);
-                    }
+/// When launched with a flag, this will be used instead of the main xlm logic. This allows
+/// us to launch ourselves to show a UI without having to spawn a window from within Tokio.
+pub fn launch_ui_main() {
+    let progress_text = Arc::new(RwLock::new(String::new()));
+    std::thread::spawn({
+        let progress_text = progress_text.clone();
+        move || {
+            let mut line = String::new();
+            let mut reader = io::BufReader::new(io::stdin());
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).is_ok() {
+                    *progress_text.write().unwrap() = line.trim().to_string();
+                }
+            }
+        }
+    });
 
-                    ctx.set_pixels_per_point(1.5);
-                    TopBottomPanel::bottom("bottom").show(ctx, |ui| {
-                        ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
-                            ui.add(Spinner::default());
-                            ui.label(*progress_text_copy.read().unwrap());
-                            ui.with_layout(Layout::right_to_left(Align::Max), |ui| {
-                                ui.horizontal(|ui| {
-                                    ui.label(format!("XLM v{}", env!("CARGO_PKG_VERSION")));
-                                });
-                            });
+    eframe::run_simple_native(
+        "XLM",
+        eframe::NativeOptions {
+            event_loop_builder: None,
+            run_and_return: true,
+            viewport: ViewportBuilder::default()
+                .with_inner_size([800.0, 500.0])
+                .with_resizable(false)
+                .with_decorations(false),
+            ..Default::default()
+        },
+        move |ctx, _frame| {
+            ctx.set_pixels_per_point(1.5);
+            TopBottomPanel::bottom("bottom").show(ctx, |ui| {
+                ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                    ui.add(Spinner::default());
+                    ui.label(progress_text.read().unwrap().as_str());
+                    ui.with_layout(Layout::right_to_left(Align::Max), |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(format!("XLM v{}", env!("CARGO_PKG_VERSION")));
                         });
                     });
-                    CentralPanel::default().show(ctx, |ui| {
-                        ui.with_layout(Layout::centered_and_justified(Direction::TopDown), |ui| {
-                            ui.heading("Starting XIVLauncher\n(this may take several minutes)");
-                        });
-                    });
-                },
-            )
-            .unwrap();
-        });
-    }
-
-    /// Closes any running egui windows regardless of the thread they're running on.
-    pub fn kill(self) {
-        self.should_close.store(true, Ordering::Relaxed);
-    }
+                });
+            });
+            CentralPanel::default().show(ctx, |ui| {
+                ui.with_layout(Layout::centered_and_justified(Direction::TopDown), |ui| {
+                    ui.heading("Starting XIVLauncher\n(this may take several minutes)");
+                });
+            });
+        },
+    )
+    .unwrap();
 }


### PR DESCRIPTION
This avoids issues with using eframe mid-application by spawning a new process dedicated to the UI. The host application sends strings to the UI application to update its status, and then kills it when it's done.

The complete flow is untested, but `while true; do date >&3; sleep 3; done 3> >(cargo run -- launch-ui)` works.

If you wanted to support more commands / messages to the UI, you could change the `progress_text` `RwLock` to a channel with an enum that gets serialized from the host. Feel free to ask for help with that.

If you want communication _back_ to the host, that would be possible (you could use `stdout`), but at that point I'd consider doing a more substantial rework to make the application UI-first.